### PR TITLE
[W7.6c][W12-2]Lee Geng Yu

### DIFF
--- a/src/seedu/addressbook/Main.java
+++ b/src/seedu/addressbook/Main.java
@@ -81,14 +81,18 @@ public class Main {
     /** Reads the user command and executes it, until the user issues the exit command.  */
     private void runCommandLoopUntilExitCommand() {
         Command command;
-        do {
-            String userCommandText = ui.getUserCommand();
-            command = new Parser().parseCommand(userCommandText);
-            CommandResult result = executeCommand(command);
-            recordResult(result);
-            ui.showResultToUser(result);
+        try {
+            do {
+                String userCommandText = ui.getUserCommand();
+                command = new Parser().parseCommand(userCommandText);
+                CommandResult result = executeCommand(command);
+                recordResult(result);
+                ui.showResultToUser(result);
 
-        } while (!ExitCommand.isExit(command));
+            } while (!ExitCommand.isExit(command));
+        } catch (StorageOperationException e) {
+                ui.showToUser(e.getMessage());
+        }
     }
 
     /** Updates the {@link #lastShownList} if the result contains a list of Persons. */
@@ -104,13 +108,16 @@ public class Main {
      *
      * @param command user command
      * @return result of the command
+     * @throws StorageOperationException if the storage file cannot be written to
      */
-    private CommandResult executeCommand(Command command)  {
+    private CommandResult executeCommand(Command command) throws StorageOperationException {
         try {
             command.setData(addressBook, lastShownList);
             CommandResult result = command.execute();
             storage.save(addressBook);
             return result;
+        } catch (StorageOperationException soe) {
+            throw soe;
         } catch (Exception e) {
             ui.showToUser(e.getMessage());
             throw new RuntimeException(e);


### PR DESCRIPTION
The original code did not handle the situation where the user accidentally made the storage file read-only while the AddressBook program is running. The program will crash in this case.

The executeCommand method has a try-catch block now, which throws the StorageOperationException to its caller, runCommandLoopUntilExitCommand. The latter method also has a try-catch block now, which will then print a message telling the user that there is an error in writing to the file. The program then exits normally without crashing.

The throws keyword is used here for checked exception (previously the general RuntimeException was thrown), and provides information to the caller of the method about the exception.